### PR TITLE
Add libvirt-daemon-common package to restore virt-admin binary

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -33,6 +33,9 @@ jobs:
       - uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
         with:
           project: kfm1zcm810
+          load: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Verify virt-admin exists
+        run: docker run --rm --entrypoint virt-admin ${{ fromJSON(steps.meta.outputs.json).tags[0] }} --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:${RELEASE}
 RUN \
   apt-get update -qq && \
   apt-get install -qq -y --no-install-recommends \
-    libvirt0 libvirt-clients && \
+    libvirt0 libvirt-daemon-common && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 COPY --from=builder /libvirt-tls-sidecar /usr/bin/libvirt-tls-sidecar


### PR DESCRIPTION
## Summary
- Adds `libvirt-daemon-common` package to the runtime container image
- Fixes TLS certificate reload for the API which requires the `virt-admin` binary
- The switch from bookworm to trixie moved `virt-admin` from `libvirt-clients` to `libvirt-daemon-common`

## Test plan
- [ ] Build the container image
- [ ] Verify `virt-admin` binary is present in the container
- [ ] Test TLS certificate renewal with `cmctl renew libvirt-api`

🤖 Generated with [Claude Code](https://claude.ai/code)